### PR TITLE
throw exceptions for encrypt_message

### DIFF
--- a/include/encryption.php
+++ b/include/encryption.php
@@ -55,14 +55,23 @@ function encrypt_message(string $public_key, string $plaintext, string $encrypti
         ) . " 2>&1"; // capture stderr
     }
 
-    $encrypted_string = shell_exec($command);
+    $output = [];
+    $return_var = 0;
+    exec($command, $output, $return_var);
+
+    if ($return_var !== 0) {
+        $error_message = "Rust decryption failed: " . implode("\n", $output);
+        error_log($error_message);
+        throw new Exception($error_message);
+    }
 
     // Optionally clean up temp file
     if (isset($tmp_pubkey_file) && file_exists($tmp_pubkey_file)) {
         unlink($tmp_pubkey_file);
     }
 
-    return $encrypted_string;
+    // Return first line if output is single-line; fallback to all lines
+    return $output[0] ?? implode("\n", $output);
 }
 
 /**

--- a/include/utils.php
+++ b/include/utils.php
@@ -278,7 +278,13 @@ function send_message(Database $db, string $username, string $to_username, strin
         return ['success' => false, 'message' => "Recipient’s public key is invalid or missing."];
     }
 
-    $encrypted = encrypt_message($pub_row['public_key'], $message, $pub_row['method']);
+    try {
+        $encrypted = encrypt_message($pub_row['public_key'], $message, $pub_row['method']);
+    } catch (Exception $e) {
+        error_log("Encryption failed: " . $e->getMessage());
+        return ['success' => false, 'message' => "Encryption failed."];
+    }
+
     $success = $db->execute(
         "INSERT INTO messages (`from`,`to`,`message`,`method`) VALUES (?,?,?,?)",
         [$username, $to_username, $encrypted, $pub_row['method']],


### PR DESCRIPTION
the `encrypt_messages` method wasn't throwing an exception when there's an error, making it difficult to debug