### PR TITLE
use `escapeshellcmd` carefully

### DIFF
--- a/include/encryption.php
+++ b/include/encryption.php
@@ -32,27 +32,23 @@ function encrypt_message(string $public_key, string $plaintext, string $encrypti
 
     if ($encryption_method == "ring_lwe") {
         // Inline key works fine for ring-lwe
-        $command = escapeshellcmd(
-            $binary_full 
+        $cmd = escapeshellcmd($binary_full);
+        $command = $cmd
             . " encrypt "
-            . "--pubkey " 
-            . escapeshellarg(trim($public_key))
-            . " " 
-            . escapeshellarg(trim($plaintext))
-        ) . " 2>&1"; // capture stderr
+            . "--pubkey " . escapeshellarg(trim($public_key))
+            . " " . escapeshellarg(trim($plaintext))
+            . " 2>&1"; //capture stderr
     } else {
         // Write public key to a temp file for module-lwe
         $tmp_pubkey_file = tempnam(sys_get_temp_dir(), "pubkey_");
         file_put_contents($tmp_pubkey_file, trim($public_key));
 
-        $command = escapeshellcmd(
-            $binary_full 
+        $cmd = escapeshellcmd($binary_full);
+        $command = $cmd
             . " encrypt "
-            . "--pubkey-file " 
-            . escapeshellarg($tmp_pubkey_file)
-            . " " 
-            . escapeshellarg(trim($plaintext))
-        ) . " 2>&1"; // capture stderr
+            . "--pubkey-file " . escapeshellarg($tmp_pubkey_file)
+            . " " . escapeshellarg(trim($plaintext))
+            . " 2>&1"; //capture stderr
     }
 
     $output = [];
@@ -60,7 +56,7 @@ function encrypt_message(string $public_key, string $plaintext, string $encrypti
     exec($command, $output, $return_var);
 
     if ($return_var !== 0) {
-        $error_message = "Rust decryption failed: " . implode("\n", $output);
+        $error_message = "Rust encryption failed: " . implode("\n", $output);
         error_log($error_message);
         throw new Exception($error_message);
     }

--- a/include/utils.php
+++ b/include/utils.php
@@ -282,7 +282,7 @@ function send_message(Database $db, string $username, string $to_username, strin
         $encrypted = encrypt_message($pub_row['public_key'], $message, $pub_row['method']);
     } catch (Exception $e) {
         error_log("Encryption failed: " . $e->getMessage());
-        return ['success' => false, 'message' => "Encryption failed."];
+        return ['success' => false, 'message' => "Encryption failed." . $e->getMessage()];
     }
 
     $success = $db->execute(


### PR DESCRIPTION
we should only use `escapeshellcmd` for the binary file. then we append the rest of the escaped command manually.